### PR TITLE
Cancel timeout after put a new value

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,15 +6,25 @@ var missCount = 0;
 
 exports.put = function(key, value, time) {
   if (debug) console.log('caching: '+key+' = '+value+' (@'+time+')');
-  var expire = time + now();
-  cache[key] = {value: value, expire: expire}
+  var oldRecord = cache[key];
+	if(oldRecord) {
+		clearTimeout(oldRecord.timeout);
+	}
 
-  // clean up space
-  if (!isNaN(expire)) {
-    setTimeout(function() {
-      exports.del(key);
-    }, time);
-  }
+	var record = {value: value, expire: expire};
+
+
+	var expire = time + now();
+	if (!isNaN(expire)) {
+
+		var timeout = setTimeout(function() {
+	    exports.del(key);
+	  }, time);
+
+		record.timeout = timeout;
+	}
+
+	cache[key] = record;
 }
 
 exports.del = function(key) {

--- a/test.js
+++ b/test.js
@@ -40,3 +40,23 @@ setTimeout(function() {
 	console.log('Cache hits: ' + cache.hits());
 	console.log('Cache misses: ' + cache.misses());	
 }, 5000);
+
+
+cache.put('timeout', 'timeout', 2000);
+
+setTimeout(function() {
+	console.log('timeout == '+cache.get('timeout'));
+	cache.put('timeout', 'timeout-re', 2000); // Cancel timeout on NEW put
+}, 1000);
+
+setTimeout(function() {
+	console.log('timeout-re == '+cache.get('timeout'));
+},3000);
+
+
+
+
+
+
+
+


### PR DESCRIPTION
When a new value has been push to a key, the timeout event linked with the key must be clear or reset. Otherwise, the new value will be remove by unintentional timeout event.

cache.put('foo', 'bar', 200);
...
cache.put('foo', 'xxx' ); // this should create a persist key/value 

// after 200ms cache.get('foo') is null
