### PR TITLE
Remove setTiemout

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,25 +4,11 @@ var debug = false;
 var hitCount = 0;
 var missCount = 0;
 
-exports.put = function(key, value, time, timeoutCallback) {
+exports.put = function(key, value, time) {
   if (debug) console.log('caching: '+key+' = '+value+' (@'+time+')');
-  var oldRecord = cache[key];
-	if (oldRecord) {
-		clearTimeout(oldRecord.timeout);
-	}
 
 	var expire = time + now();
 	var record = {value: value, expire: expire};
-
-	if (!isNaN(expire)) {
-		var timeout = setTimeout(function() {
-	    exports.del(key);
-	    if (typeof timeoutCallback === 'function') {
-	    	timeoutCallback(key);
-	    }
-	  }, time);
-		record.timeout = timeout;
-	}
 
 	cache[key] = record;
 }


### PR DESCRIPTION
The set timeout is unneeded and cases problems with nodeunit, express, and most applications.  It should be removed.
