### PR TITLE
Fetch or resolve flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,32 @@ which should print
     Houdini will now disapear
     Houdini is null
 
+You may also use the fetch-or-resolve flow with a non-blocking behavior and structure
+```javascript
+var cache = require('memory-cache');
+
+function get_username(userid, cb) {
+  cache.fetch("username_"+userid, 10000).from(function(cache) {
+    //pseudocode
+    expensive_database_access(function(err, res) {
+      cache.resolve(res.name);
+    })
+  }).then(cb);
+}
+
+get_username(123, function(name) {
+  console.log(name);
+});
+
+```
+the __from__ block will only be run if there is a cache miss. Otherwise the value will be resolved right away.
+
+
 ## API
 
 ### put = function(key, value, time)
 
-* Simply stores a value. 
+* Simply stores a value.
 * If time isn't passed in, it is stored forever.
 * Will actually remove the value in the specified time (via `setTimeout`)
 
@@ -83,7 +104,7 @@ which should print
 * A way of walking the cache for diagnostic purposes
 
 ## Note on Patches/Pull Requests
- 
+
 * Fork the project.
 * Make your feature addition or bug fix.
 * Send me a pull request.


### PR DESCRIPTION
Added the option use the cache within a non blocking friendly flow. It is based on Rails' cache fetch function but adapted to javascript and a non-blocking architecture.

The current API is for the **fetch** function is: 
```javascript
    cache.fetch("key").from(expensive_callback).then(result_callback)
````
**expensive_callback** is a non blocking function that *calculates* the value for the given *key*. It is **only** called if there is a **cache miss**. In the case there is **no** cache miss, **result_callback** will be called instantaneously with the value.

Here is one example of usage:
```javascript
    function welcome_user(userid) {  
      cache.fetch("username-"+userid, 60000).from(username_from_database).then(print_welcome)

      function print_welcome(username) {
        console.log("Welcome " + username)
      })

      function username_from_database(cache) {
        pg.connect("postgres://localhost:3000", function(err, client, done) {
            query = "SELECT username FROM users WHERE id = " + userid
            client.query(query, function(err, result) {
              done()
              username = result.rows[0].username
              cache.resolve(username)
          })
        })
      }  
    }
````