### PR TITLE
Fixed bug which caused keys which are on the Object prototype to always be in the cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var cache = {};
+var cache = Object.create(null);
 
 function now() {
   return (new Date()).getTime();
@@ -69,7 +69,7 @@ exports.clear = function() {
     }
   }
   size = 0;
-  cache = {};
+  cache = Object.create(null);
   if (debug) {
     hitCount = 0;
     missCount = 0;
@@ -102,8 +102,7 @@ exports.memsize = function() {
   var size = 0,
     key;
   for (key in cache) {
-    if (cache.hasOwnProperty(key))
-      size++;
+    size++;
   }
   return size;
 };

--- a/test.js
+++ b/test.js
@@ -279,6 +279,15 @@ describe('node-cache', function() {
       clock.tick(1000);
       expect(cache.get('key')).to.be.null;
     });
+
+    it('should return null given a key which is a property on the Object prototype', function() {
+      expect(cache.get('toString')).to.be.null;
+    });
+
+    it('should allow reading the value for a key which is a property on the Object prototype', function() {
+      cache.put('toString', 'value');
+      expect(cache.get('toString')).to.equal('value');
+    });
   });
 
   describe('size()', function() {


### PR DESCRIPTION
Calling `cache.get('toString')` on a fresh cache currently returns `undefined` instead of `null` because `toString()` is defined on the prototype for `{}`. Instead, we want to create an object which has nothing on the prototype, which we can do by calling `Object.create(null)`. See [this StackOverflow post](http://stackoverflow.com/questions/16666231/difference-between-object-createobject-prototype-object-createobject-and-o) for more details. I also added some tests to make sure this now works. The first test fails with current `master` but passes in this branch.