### PR TITLE
Added optional createStore() method.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,120 +1,128 @@
 'use strict';
 
-var cache = Object.create(null);
-var debug = false;
-var hitCount = 0;
-var missCount = 0;
-var size = 0;
+function createStore () {
+  var store = {};
+  var cache = Object.create(null);
+  var debug = false;
+  var hitCount = 0;
+  var missCount = 0;
+  var size = 0;
 
-exports.put = function(key, value, time, timeoutCallback) {
-  if (debug) {
-    console.log('caching: %s = %j (@%s)', key, value, time);
-  }
-  var oldRecord = cache[key];
-  if (oldRecord) {
-    clearTimeout(oldRecord.timeout);
-  } else {
-    size++;
-  }
-
-  var expire = time + Date.now();
-  var record = {
-    value: value,
-    expire: expire
-  };
-
-  if (!isNaN(expire)) {
-    var timeout = setTimeout(function() {
-      exports.del(key);
-      if (typeof timeoutCallback === 'function') {
-        timeoutCallback(key);
-      }
-    }, time);
-    record.timeout = timeout;
-  }
-
-  cache[key] = record;
-};
-
-exports.del = function(key) {
-  var canDelete = true;
-
-  var oldRecord = cache[key];
-  if (oldRecord) {
-    clearTimeout(oldRecord.timeout);
-    if (!isNaN(oldRecord.expire) && oldRecord.expire < Date.now()) {
-      canDelete = false;
+  store.put = function(key, value, time, timeoutCallback) {
+    if (debug) {
+      console.log('caching: %s = %j (@%s)', key, value, time);
     }
-  } else {
-    canDelete = false;
-  }
-
-  if (canDelete) {
-    size--;
-    delete cache[key];
-  }
-
-  return canDelete;
-};
-
-exports.clear = function() {
-  for (var key in cache) {
     var oldRecord = cache[key];
     if (oldRecord) {
       clearTimeout(oldRecord.timeout);
-    }
-  }
-  size = 0;
-  cache = Object.create(null);
-  if (debug) {
-    hitCount = 0;
-    missCount = 0;
-  }
-};
-
-exports.get = function(key) {
-  var data = cache[key];
-  if (typeof data != "undefined") {
-    if (isNaN(data.expire) || data.expire >= Date.now()) {
-      if (debug) hitCount++;
-      return data.value;
     } else {
-      // free some space
-      if (debug) missCount++;
+      size++;
+    }
+
+    var expire = time + Date.now();
+    var record = {
+      value: value,
+      expire: expire
+    };
+
+    if (!isNaN(expire)) {
+      var timeout = setTimeout(function() {
+        store.del(key);
+        if (typeof timeoutCallback === 'function') {
+          timeoutCallback(key);
+        }
+      }, time);
+      record.timeout = timeout;
+    }
+
+    cache[key] = record;
+  };
+
+  store.del = function(key) {
+    var canDelete = true;
+
+    var oldRecord = cache[key];
+    if (oldRecord) {
+      clearTimeout(oldRecord.timeout);
+      if (!isNaN(oldRecord.expire) && oldRecord.expire < Date.now()) {
+        canDelete = false;
+      }
+    } else {
+      canDelete = false;
+    }
+
+    if (canDelete) {
       size--;
       delete cache[key];
     }
-  } else if (debug) {
-    missCount++;
-  }
-  return null;
-};
 
-exports.size = function() {
-  return size;
-};
+    return canDelete;
+  };
 
-exports.memsize = function() {
-  var size = 0,
-    key;
-  for (key in cache) {
-    size++;
-  }
-  return size;
-};
+  store.clear = function() {
+    for (var key in cache) {
+      var oldRecord = cache[key];
+      if (oldRecord) {
+        clearTimeout(oldRecord.timeout);
+      }
+    }
+    size = 0;
+    cache = Object.create(null);
+    if (debug) {
+      hitCount = 0;
+      missCount = 0;
+    }
+  };
 
-exports.debug = function(bool) {
-  debug = bool;
-};
+  store.get = function(key) {
+    var data = cache[key];
+    if (typeof data != "undefined") {
+      if (isNaN(data.expire) || data.expire >= Date.now()) {
+        if (debug) hitCount++;
+        return data.value;
+      } else {
+        // free some space
+        if (debug) missCount++;
+        size--;
+        delete cache[key];
+      }
+    } else if (debug) {
+      missCount++;
+    }
+    return null;
+  };
 
-exports.hits = function() {
-  return hitCount;
-};
+  store.size = function() {
+    return size;
+  };
 
-exports.misses = function() {
-  return missCount;
-};
+  store.memsize = function() {
+    var size = 0,
+      key;
+    for (key in cache) {
+      size++;
+    }
+    return size;
+  };
 
-exports.keys = function() {
-  return Object.keys(cache);
-};
+  store.debug = function(bool) {
+    debug = bool;
+  };
+
+  store.hits = function() {
+    return hitCount;
+  };
+
+  store.misses = function() {
+    return missCount;
+  };
+
+  store.keys = function() {
+    return Object.keys(cache);
+  };
+
+  return store;
+}
+
+module.exports = createStore();
+module.exports.createStore = createStore;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "git://github.com/ptarjan/node-cache.git"
   },
   "scripts": {
-    "test": "node test.js"
+    "test": "./node_modules/.bin/gulp test"
   },
   "license": "BSD",
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -561,4 +561,18 @@ describe('node-cache', function() {
       expect(cache.keys()).to.deep.equal([]);
     });
   });
+
+  describe('createStore()', function() {
+    before(function() {
+      cache.debug(false);
+    });
+
+    it('it should not conflict with global store', function() {
+      var localCache = cache.createStore();
+      cache.put('test', 123);
+      localCache.put('test', 456);
+      expect(cache.get('test')).to.be.equal(123);
+      expect(localCache.get('test')).to.equal(456);
+    });
+  });
 });


### PR DESCRIPTION
See issue https://github.com/ptarjan/node-cache/issues/41

I just wrapped the whole module into a createStore function. This is a backwards compatible change and simply adds the option to have a local cache to avoid conflicting with other modules.

The diff pretty bad. I just replaced all `exports` with `store`. Added `var store = {};` at the top. Wrapped the whole thing with a `function createStore() {}` and `module.exports = createStore(); module.exports.createStore = createStore`.