### PR TITLE
Fixed bug with auto-expiring keys with no expiration time

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,12 +29,14 @@ exports.put = function(key, value, time, timeoutCallback) {
     expire: time + Date.now()
   };
 
-  record.timeout = setTimeout(function() {
-    exports.del(key);
-    if (timeoutCallback) {
-      timeoutCallback(key);
-    }
-  }, time);
+  if (!isNaN(record.expire)) {
+    record.timeout = setTimeout(function() {
+      exports.del(key);
+      if (timeoutCallback) {
+        timeoutCallback(key);
+      }
+    }, time);
+  }
 
   cache[key] = record;
 

--- a/test.js
+++ b/test.js
@@ -317,6 +317,12 @@ describe('node-cache', function() {
       });
     });
 
+    it('should not set a timeout given no expiration time', function() {
+      cache.put('key', 'value');
+      clock.tick(1000);
+      expect(cache.get('key')).to.equal('value');
+    });
+
     it('should return the corresponding value of a non-expired key in the cache', function() {
       cache.put('key', 'value', 1000);
       clock.tick(999);


### PR DESCRIPTION
Fixes #51.

Keys which do not specify an expiration time were being auto-expired due to a bug in my PR #48. The fix is to only set the expiration callback if the expiration time is actually a valid number. The test suite did not catch this because of the mocked timer. But I added a new test which would catch this issue in the future.

We should probably get a new release out so no one else upgrades and is broken.