### PR TITLE
Expire Conditional

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ exports.del = function(key) {
   var oldRecord = cache[key];
   if (oldRecord) {
     clearTimeout(oldRecord.timeout);
-    if (!isNaN(oldRecord.expire) && oldRecord.expire < Date.now()) {
+    if (!isNaN(oldRecord.expire) && oldRecord.expire > Date.now()) {
       canDelete = false;
     }
   } else {


### PR DESCRIPTION
If time has been set in cache, oldRecord.expire should be greater than
Date.now() to prevent deletion.  Once time has expired, the two will
equal which will allow canDelete=true.

Fixes #56 