### PR TITLE
Removing the limit for timeout to be 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ exports.put = function(key, value, time, timeoutCallback) {
     console.log('caching: %s = %j (@%s)', key, value, time);
   }
 
-  if (typeof time !== 'undefined' && (typeof time !== 'number' || isNaN(time) || time <= 0)) {
+  if (typeof time !== 'undefined' && (typeof time !== 'number' || isNaN(time) || time < 0)) {
     throw new Error('Cache timeout must be a positive number');
   } else if (typeof timeoutCallback !== 'undefined' && typeof timeoutCallback !== 'function') {
     throw new Error('Cache timeout callback must be a function');

--- a/test.js
+++ b/test.js
@@ -57,12 +57,6 @@ describe('node-cache', function() {
       }).to.throw();
     });
 
-    it('should throw an error given a timeout of 0', function() {
-      expect(function() {
-        cache.put('key', 'value', 0);
-      }).to.throw();
-    });
-
     it('should throw an error given a negative timeout', function() {
       expect(function() {
         cache.put('key', 'value', -100);


### PR DESCRIPTION
Even if in production, it's not really adequate to have '0' for caching, I still think it should be a possibility since there's little to no difference in functionality between that and '1'.

From a personal standpoint, I do use 0 when I want to test out functionality that uses the cache and want to expire the cache straight away.
