### PR TITLE
Fixed del function: removed "expired" parameter checking condition.

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,9 +49,6 @@ exports.del = function(key) {
   var oldRecord = cache[key];
   if (oldRecord) {
     clearTimeout(oldRecord.timeout);
-    if (!isNaN(oldRecord.expire) && oldRecord.expire < Date.now()) {
-      canDelete = false;
-    }
   } else {
     canDelete = false;
   }


### PR DESCRIPTION
Three reasons:
1. If I want to manually remove item it should not depends on it's parameters.
2. Items with "expired" parameter will be removed automatically, so it just not make any sense to not allow remove them before the expiration time.
3. Take a look at this clearTimeout call. If item timeout is cleared and item is not removed, then "del" function is literally equal to clearTimeout for items with "expire" parameter - it removes nothing.
