### PR TITLE
Allow importing and exporting to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,14 @@ which should print
 * Returns a JSON string representing all the cache data
 * Any timeoutCallbacks will be ignored
 
-### importJson = function(string)
+### importJson = function(json: string, options: { skipDuplicates: boolean })
 
 * Merges all the data from a previous call to `export` into the cache
-* Any existing entries before an `import` will remain in the cache (or be overwritten)
+* Any existing entries before an `import` will remain in the cache
+* Any duplicate keys will be overwritten, unless `skipDuplicates` is `true`
 * Any entries that would have expired since being exported will expire upon being imported (but their callbacks will not be invoked)
+* Available `options`:
+  * `skipDuplicates`: If `true`, any duplicate keys will be ignored when importing them. Defaults to `false`.
 * Returns the new size of the cache
 
 ### Cache = function()

--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ which should print
 
 * Returns all the cache keys
 
+### exportJson = function()
+
+* Returns a JSON string representing all the cache data
+* Any timeoutCallbacks will be ignored
+
+### importJson = function(string)
+
+* Merges all the data from a previous call to `export` into the cache
+* Any existing entries before an `import` will remain in the cache (or be overwritten)
+* Any entries that would have expired since being exported will expire upon being imported (but their callbacks will not be invoked)
+* Returns the new size of the cache
+
 ### Cache = function()
 
 * Cache constructor

--- a/index.js
+++ b/index.js
@@ -144,12 +144,24 @@ function Cache () {
     return JSON.stringify(plainJsCache);
   };
 
-  this.importJson = function(jsonToImport) {
+  this.importJson = function(jsonToImport, options) {
     var cacheToImport = JSON.parse(jsonToImport);
     var currTime = Date.now();
 
+    var skipDuplicates = options && options.skipDuplicates;
+
     for (var key in cacheToImport) {
       if (cacheToImport.hasOwnProperty(key)) {
+        if (skipDuplicates) {
+          var existingRecord = _cache[key];
+          if (existingRecord) {
+            if (_debug) {
+              console.log('Skipping duplicate imported key \'%s\'', key);
+            }
+            continue;
+          }
+        }
+
         var record = cacheToImport[key];
 
         // This could possibly be `'NaN'` if there's no expiry set.

--- a/index.js
+++ b/index.js
@@ -164,17 +164,21 @@ function Cache () {
 
         var record = cacheToImport[key];
 
-        // This could possibly be `'NaN'` if there's no expiry set.
+        // record.expire could be `'NaN'` if no expiry was set.
+        // Try to subtract from it; a string minus a number is `NaN`, which is perfectly fine here.
         var remainingTime = record.expire - currTime;
 
         if (remainingTime <= 0) {
-          // Delete any record that might exist with the same key.
+          // Delete any record that might exist with the same key, since this key is expired.
           this.del(key);
           continue;
         }
 
-        // Remaining time is either positive, or `'NaN'`.
-        this.put(key, record.value, remainingTime > 0 ? remainingTime : undefined);
+        // Remaining time must now be either positive or `NaN`,
+        // but `put` will throw an error if we try to give it `NaN`.
+        remainingTime = remainingTime > 0 ? remainingTime : undefined;
+
+        this.put(key, record.value, remainingTime);
       }
     }
 

--- a/test.js
+++ b/test.js
@@ -769,6 +769,7 @@ describe('node-cache', function() {
       cache.put('key2', 'value2', 1000);
       var exportedJson = cache.exportJson();
 
+      cache.clear();
       cache.put('key1', 'changed value', 5000);
       cache.put('key3', 'value3', 500);
 
@@ -779,13 +780,13 @@ describe('node-cache', function() {
           value: 'changed value',
           expire: START_TIME + 5000,
         },
-        key2: {
-          value: 'value2',
-          expire: START_TIME + 1000,
-        },
         key3: {
           value: 'value3',
           expire: START_TIME + 500,
+        },
+        key2: {
+          value: 'value2',
+          expire: START_TIME + 1000,
         },
       }));
     });

--- a/test.js
+++ b/test.js
@@ -762,6 +762,34 @@ describe('node-cache', function() {
       }));
     });
 
+    it('should import records into an already-existing cache and skip duplicates', function() {
+      cache.debug(true);
+
+      cache.put('key1', 'value1');
+      cache.put('key2', 'value2', 1000);
+      var exportedJson = cache.exportJson();
+
+      cache.put('key1', 'changed value', 5000);
+      cache.put('key3', 'value3', 500);
+
+      cache.importJson(exportedJson, { skipDuplicates: true });
+
+      expect(cache.exportJson()).to.equal(JSON.stringify({
+        key1: {
+          value: 'changed value',
+          expire: START_TIME + 5000,
+        },
+        key2: {
+          value: 'value2',
+          expire: START_TIME + 1000,
+        },
+        key3: {
+          value: 'value3',
+          expire: START_TIME + 500,
+        },
+      }));
+    });
+
     it('should import with updated expire times', function() {
       cache.put('key1', 'value1', 500);
       cache.put('key2', 'value2', 1000);


### PR DESCRIPTION
Awesome library, love the unit tests! I'm using it for caching web response data in a mobile app, and I find import/export to be valuable for saving to disk and restoring the cache later (for example, if you kill the app and then open it again, restore the offline data in case there's no internet anymore).

### exportJson = function()

* Returns a JSON string representing all the cache data
* Any timeoutCallbacks will be ignored, as these can't easily be serialized

### importJson = function(json: string, options: { skipDuplicates: boolean })

* Merges all the data from a previous call to `export` into the cache
* Any existing entries before an `import` will remain in the cache
* Any duplicate keys will be overwritten, unless `skipDuplicates` is `true`
* Any entries that would have expired since being exported will expire upon being imported (but their callbacks will not be invoked)
* Available `options`:
  * `skipDuplicates`: If `true`, any duplicate keys will be ignored when importing them. Defaults to `false`.
* Returns the new size of the cache
