### PR TITLE
Modify put function to support a time that exceeds setTimeout's maximum time

### DIFF
--- a/test.js
+++ b/test.js
@@ -84,6 +84,17 @@ describe('node-cache', function() {
       expect(spy).to.have.been.calledOnce.and.calledWith('key', 'value');
     });
 
+    it('should cause the timeout callback to fire once 30 days later', function() {
+      var spy = sinon.spy();
+      const thirtyDays = 2592000000;
+      const timeoutMax = 2147483648;
+      cache.put('key', 'value', thirtyDays, spy);
+      clock.tick(timeoutMax);
+      expect(spy).to.not.have.been.called;
+      clock.tick(thirtyDays-timeoutMax);
+      expect(spy).to.have.been.calledOnce.and.calledWith('key', 'value')
+    });
+
     it('should override the timeout callback on a new put() with a different timeout callback', function() {
       var spy1 = sinon.spy();
       var spy2 = sinon.spy();
@@ -196,7 +207,7 @@ describe('node-cache', function() {
       clock.tick(1000);
       expect(spy).to.not.have.been.called;
     });
-    
+
     it('should handle deletion of many items', function(done) {
       clock.restore();
       var num = 1000;


### PR DESCRIPTION
setTimeout can support a maximum of 2147483647 milliseconds (about 24.9 days), which limits the time that the put function can support. Now it can support the maximum safe integer supported by the javascript number primitive (9007199254740991). 9007199254740991 milliseconds is about 285616.41 years.