### PR TITLE
Throw error is expire time is set too high

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ function Cache () {
       console.log('caching: %s = %j (@%s)', key, value, time);
     }
 
-    if (typeof time !== 'undefined' && (typeof time !== 'number' || isNaN(time) || time <= 0)) {
-      throw new Error('Cache timeout must be a positive number');
+    if (typeof time !== 'undefined' && (typeof time !== 'number' || isNaN(time) || time <= 0 || time >= Math.pow(2, 32) / 2)) {
+      throw new Error('Cache timeout must be a positive number that is less than 2^32');
     } else if (typeof timeoutCallback !== 'undefined' && typeof timeoutCallback !== 'function') {
       throw new Error('Cache timeout callback must be a function');
     }

--- a/test.js
+++ b/test.js
@@ -64,6 +64,12 @@ describe('node-cache', function() {
       }).to.throw();
     });
 
+    it('should throw an error given a timeout of more than 2147483647', function() {
+      expect(function() {
+        cache.put('key', 'value', 2147483648);
+      }).to.throw();
+    });
+
     it('should throw an error given a negative timeout', function() {
       expect(function() {
         cache.put('key', 'value', -100);


### PR DESCRIPTION
We will now throw an error if passing in an invalid value to the time parameter