### PR TITLE
Unref`d cache timer to prevent event loop hanging

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ function Cache () {
           timeoutCallback(key, value);
         }
       }.bind(this), time);
+      record.timeout.unref();
     }
 
     _cache[key] = record;


### PR DESCRIPTION
The timeout handler for the cache was never unreferenced so it would hold the event loop open even after the program had finished running. We were running into this issue when attempting to the use the cache within lambdas.

https://nodejs.org/api/timers.html#timers_timeout_unref
