### PR TITLE
Add 'deleteOnTimeout' configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ which should print
 
 * Returns all the cache keys
 
+### deleteOnTimeout = function(bool)
+
+* Turns on or off automatic delete on TTL expiration
+* Defaults to on
+
 ### exportJson = function()
 
 * Returns a JSON string representing all the cache data

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ function Cache () {
   var _missCount = 0;
   var _size = 0;
   var _debug = false;
+  var _deleteOnTimeout = true;
 
   this.put = function(key, value, time, timeoutCallback) {
     if (_debug) {
@@ -32,7 +33,9 @@ function Cache () {
 
     if (!isNaN(record.expire)) {
       record.timeout = setTimeout(function() {
-        _del(key);
+        if (_deleteOnTimeout) {
+          _del(key);
+        }
         if (timeoutCallback) {
           timeoutCallback(key, value);
         }
@@ -127,6 +130,10 @@ function Cache () {
   this.keys = function() {
     return Object.keys(_cache);
   };
+
+  this.deleteOnTimeout = function(bool) {
+    _deleteOnTimeout = bool;
+  }
 
   this.exportJson = function() {
     var plainJsCache = {};

--- a/index.js
+++ b/index.js
@@ -35,6 +35,10 @@ function Cache () {
       record.timeout = setTimeout(function() {
         if (_deleteOnTimeout) {
           _del(key);
+        } else {
+          var record = _cache[key];
+          delete record.expire;
+          delete record.timeout;
         }
         if (timeoutCallback) {
           timeoutCallback(key, value);


### PR DESCRIPTION
'deleteOnTimeout' controls whether a key is removed when the ttl expires or whether it is kept. Default is true (behavior is unchanged). If set to false, key will not be removed when ttl expires, but timeout callback will be invoked.